### PR TITLE
virtual network: autogenerate from inventory

### DIFF
--- a/bin/ffhivnet-up
+++ b/bin/ffhivnet-up
@@ -6,8 +6,17 @@ if [  $# -ne 0 ]; then
 	echo "Usage: $0"
 	exit 1
 fi
- 
+
+# filter host+address definitions from inventory into definition of
+# virtual network
+
+VNET_XML_TMP=$(mktemp /tmp/ffhi-prepare-vnet.XXXXXX)
+ansible-playbook $HERE/../vnet.yml -e "in=$HERE/vnet.xml.j2 out=$VNET_XML_TMP" > /dev/null
+
 virsh --connect=qemu:///system net-undefine ffhivnet > /dev/null 2>&1
-virsh --connect=qemu:///system net-define $HERE/ffhivnet.xml
+virsh --connect=qemu:///system net-define $VNET_XML_TMP
 virsh --connect=qemu:///system net-start ffhivnet
 virsh --connect=qemu:///system net-list
+
+rm -f $VNET_XML_TMP
+

--- a/bin/vnet.xml.j2
+++ b/bin/vnet.xml.j2
@@ -1,0 +1,13 @@
+<network>
+  <name>ffhivnet</name>
+  <bridge name="ffhibr0"/>
+  <forward mode="nat"/>
+  <ip address="192.168.3.1" netmask="255.255.255.0">
+    <dhcp>
+      <range start="192.168.3.2" end="192.168.3.254"/>
+{% for host in groups['all'] %}
+      <host name="{{ host }}" ip="{{ hostvars[host]['ansible_host_v4'] }}"/>
+{% endfor %}
+    </dhcp>
+  </ip>
+</network>

--- a/vnet.yml
+++ b/vnet.yml
@@ -1,0 +1,14 @@
+---
+  
+#
+# used by bin/vnet-up
+#
+
+- hosts: localhost
+  connection: local
+
+  tasks:
+
+  - name: create virtual network from inventory
+    template: src={{ in }} dest={{ out }}
+


### PR DESCRIPTION
Up to now, we had to put the addresses for all our hosts into two
separate places. As we have this information in the inventory anyway,
use it to autogenerate the definition of the virtual network.

Signed-off-by: Robert Schwebel <robert@schwebel.de>